### PR TITLE
Fix dashboard placeholder map prefix usage

### DIFF
--- a/dashboards/views.py
+++ b/dashboards/views.py
@@ -294,13 +294,15 @@ def dashboard_overview(request):
 
     employee_map = _build_placeholder_map(
         [v.get("corretor__nome") for v in vendas_por_corretor]
-        + [item.get("corretor") for item in inadimplencia_por_corretor]
+        + [item.get("corretor") for item in inadimplencia_por_corretor],
+        prefix="employee",
     )
     company_map = _build_placeholder_map(
         [v.get("empreendimento__nome") for v in vendas_por_corretor]
         + [item.get("empreendimento__nome") for item in custo_por_empreendimento]
         + [item.get("empreendimento__nome") for item in planejamento_vs_realizado]
-        + [item.get("empreendimento") for item in margem_por_empreendimento]
+        + [item.get("empreendimento") for item in margem_por_empreendimento],
+        prefix="company",
     )
 
     for venda in vendas_por_corretor:


### PR DESCRIPTION
## Summary
- pass the required prefix argument when building employee and company placeholder maps in the dashboard

## Testing
- python manage.py check *(fails: missing Django dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c8e97ba4832480cb01c96be1cc47)